### PR TITLE
Freeze the version of opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ rospkg
 requests
 pypcd
 numpy==1.11.1
-opencv-python
+opencv-python==4.2.0.32


### PR DESCRIPTION
## What?
Freeze the version of opencv-python to 4.2.0.32

## Why?
Python2 is no longer supported by the latest opencv-python